### PR TITLE
Ignore older events

### DIFF
--- a/charts/cronitor-kubernetes/Chart.yaml
+++ b/charts/cronitor-kubernetes/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 name: cronitor-kubernetes
 description: |
   Helm chart to deploy the Cronitor Kubernetes agent to automatically monitor your CronJobs
-version: "0.2.2"
-appVersion: "0.2.2"
+version: "0.2.3"
+appVersion: "0.2.3"


### PR DESCRIPTION
Attempts to ignore "stale" events coming from Kubernetes from before the agent start.

The code is likely fine, but please review to help make sure the logic itself is sound. Is there some reason we'd need these events? Would we somehow skip actual events that matter? Etc.

This PR is based on the assumption that some users are seeing monitors show up without names due to stale events from Jobs that no longer exist.