### PR TITLE
Hotfix: Ignoring stale events

### DIFF
--- a/charts/cronitor-kubernetes/Chart.yaml
+++ b/charts/cronitor-kubernetes/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 name: cronitor-kubernetes
 description: |
   Helm chart to deploy the Cronitor Kubernetes agent to automatically monitor your CronJobs
-version: "0.2.5"
-appVersion: "0.2.5"
+version: "0.3.0"
+appVersion: "0.3.0"

--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ func main() {
 	if os.Getenv("SENTRY_ENABLED") == "true" {
 		log.Info("Enabling Sentry instrumentation...")
 		err := sentry.Init(sentry.ClientOptions{
-			Dsn: "https://e36895dc862642deae6ba3773924d1f6@o131626.ingest.sentry.io/6031178",
+			Dsn:              "https://e36895dc862642deae6ba3773924d1f6@o131626.ingest.sentry.io/6031178",
 			AttachStacktrace: true,
 		})
 		if err != nil {

--- a/pkg/collector/jobevent_watcher.go
+++ b/pkg/collector/jobevent_watcher.go
@@ -229,7 +229,7 @@ func (e EventHandler) CheckJobIsWatched(jobNamespace string, jobName string) boo
 
 func (e EventHandler) OnAdd(obj interface{}) {
 	event := obj.(*corev1.Event)
-	eventTime := event.EventTime
+	eventTime := event.LastTimestamp
 
 	switch event.InvolvedObject.Kind {
 	case "Job":
@@ -237,13 +237,13 @@ func (e EventHandler) OnAdd(obj interface{}) {
 
 		// If this event is an older, stale event--e.g., it happened before this version of the agent started to run--
 		// then ignore the event
-		if eventTime.BeforeTime(&StartupTime) {
+		if eventTime.Before(&StartupTime) {
 			log.WithFields(log.Fields{
 				"name":         typedEvent.InvolvedObject.Name,
 				"kind":         typedEvent.InvolvedObject.Kind,
 				"eventMessage": typedEvent.Message,
 				"eventReason":  typedEvent.Reason,
-			}).Debugf("Ignored event from the past, happened %v, agent startup time %v", eventTime, StartupTime)
+			}).Infof("Ignored event from the past, happened %v, agent startup time %v", eventTime, StartupTime)
 			return
 		}
 
@@ -267,13 +267,13 @@ func (e EventHandler) OnAdd(obj interface{}) {
 
 		// If this event is an older, stale event--e.g., it happened before this version of the agent started to run--
 		// then ignore the event
-		if eventTime.BeforeTime(&StartupTime) {
+		if eventTime.Before(&StartupTime) {
 			log.WithFields(log.Fields{
 				"name":         typedEvent.InvolvedObject.Name,
 				"kind":         typedEvent.InvolvedObject.Kind,
 				"eventMessage": typedEvent.Message,
 				"eventReason":  typedEvent.Reason,
-			}).Debugf("Ignored event from the past, happened %v, agent startup time %v", eventTime, StartupTime)
+			}).Infof("Ignored event from the past, happened %v, agent startup time %v", eventTime, StartupTime)
 			return
 		}
 


### PR DESCRIPTION
The event staleness checker added in #9 used a property of the Event object that is not always present. This resulted in events mistakenly appearing to be in the past that were actually the present--and as a result, events would be ignored by the staleness checker and not sent to Cronitor.

Two key changes here:
* Use `LastTimestamp` to ensure timestamps are always available
* Change log level of ignored events from DEBUG to INFO so that they show up in logging by default