### PR TITLE
Add retry watcher logic to fix job watch implementation

### DIFF
--- a/pkg/collector/jobevent_watcher.go
+++ b/pkg/collector/jobevent_watcher.go
@@ -21,7 +21,7 @@ import (
 	"k8s.io/client-go/tools/watch"
 )
 
-var StartupTime = meta_v1.Now()
+var startupTime = meta_v1.Now()
 
 type EventHandler struct {
 	collection *CronJobCollection
@@ -228,13 +228,13 @@ func (e EventHandler) OnAdd(obj interface{}) {
 
 		// If this event is an older, stale event--e.g., it happened before this version of the agent started to run--
 		// then ignore the event
-		if eventTime.Before(&StartupTime) {
+		if eventTime.Before(&startupTime) {
 			log.WithFields(log.Fields{
 				"name":         typedEvent.InvolvedObject.Name,
 				"kind":         typedEvent.InvolvedObject.Kind,
 				"eventMessage": typedEvent.Message,
 				"eventReason":  typedEvent.Reason,
-			}).Infof("Ignored event from the past, happened %v, agent startup time %v", eventTime, StartupTime)
+			}).Infof("Ignored event from the past, happened %v, watch startup time %v", eventTime, startupTime)
 			return
 		}
 
@@ -258,13 +258,13 @@ func (e EventHandler) OnAdd(obj interface{}) {
 
 		// If this event is an older, stale event--e.g., it happened before this version of the agent started to run--
 		// then ignore the event
-		if eventTime.Before(&StartupTime) {
+		if eventTime.Before(&startupTime) {
 			log.WithFields(log.Fields{
 				"name":         typedEvent.InvolvedObject.Name,
 				"kind":         typedEvent.InvolvedObject.Kind,
 				"eventMessage": typedEvent.Message,
 				"eventReason":  typedEvent.Reason,
-			}).Infof("Ignored event from the past, happened %v, agent startup time %v", eventTime, StartupTime)
+			}).Infof("Ignored event from the past, happened %v, watch startup time %v", eventTime, startupTime)
 			return
 		}
 
@@ -344,7 +344,8 @@ func NewJobsEventWatcher(collection *CronJobCollection) *WatchWrapper {
 		namespace = collection.kubernetesNamespace
 	}
 	watchFunc := func(options meta_v1.ListOptions) (apiWatch.Interface, error) {
-		// Return watcher with 10m timeout
+		// Setting the time here *should* be safe, as when watchFunc runs, the watch handler by definition is stopped
+		startupTime = meta_v1.Now()
 		return clientset.CoreV1().Events(namespace).Watch(context.Background(), meta_v1.ListOptions{})
 	}
 

--- a/pkg/collector/jobevent_watcher.go
+++ b/pkg/collector/jobevent_watcher.go
@@ -21,7 +21,7 @@ import (
 	"k8s.io/client-go/tools/watch"
 )
 
-var startupTime = meta_v1.Now()
+var watchStartTime = meta_v1.Now()
 
 type EventHandler struct {
 	collection *CronJobCollection
@@ -228,13 +228,13 @@ func (e EventHandler) OnAdd(obj interface{}) {
 
 		// If this event is an older, stale event--e.g., it happened before this version of the agent started to run--
 		// then ignore the event
-		if eventTime.Before(&startupTime) {
+		if eventTime.Before(&watchStartTime) {
 			log.WithFields(log.Fields{
 				"name":         typedEvent.InvolvedObject.Name,
 				"kind":         typedEvent.InvolvedObject.Kind,
 				"eventMessage": typedEvent.Message,
 				"eventReason":  typedEvent.Reason,
-			}).Infof("Ignored event from the past, happened %v, watch startup time %v", eventTime, startupTime)
+			}).Infof("Ignored event from the past, happened %v, watch startup time %v", eventTime, watchStartTime)
 			return
 		}
 
@@ -258,13 +258,13 @@ func (e EventHandler) OnAdd(obj interface{}) {
 
 		// If this event is an older, stale event--e.g., it happened before this version of the agent started to run--
 		// then ignore the event
-		if eventTime.Before(&startupTime) {
+		if eventTime.Before(&watchStartTime) {
 			log.WithFields(log.Fields{
 				"name":         typedEvent.InvolvedObject.Name,
 				"kind":         typedEvent.InvolvedObject.Kind,
 				"eventMessage": typedEvent.Message,
 				"eventReason":  typedEvent.Reason,
-			}).Infof("Ignored event from the past, happened %v, watch startup time %v", eventTime, startupTime)
+			}).Infof("Ignored event from the past, happened %v, watch startup time %v", eventTime, watchStartTime)
 			return
 		}
 
@@ -345,7 +345,7 @@ func NewJobsEventWatcher(collection *CronJobCollection) *WatchWrapper {
 	}
 	watchFunc := func(options meta_v1.ListOptions) (apiWatch.Interface, error) {
 		// Setting the time here *should* be safe, as when watchFunc runs, the watch handler by definition is stopped
-		startupTime = meta_v1.Now()
+		watchStartTime = meta_v1.Now()
 		return clientset.CoreV1().Events(namespace).Watch(context.Background(), meta_v1.ListOptions{})
 	}
 

--- a/pkg/collector/jobevent_watcher.go
+++ b/pkg/collector/jobevent_watcher.go
@@ -339,7 +339,6 @@ func (w WatchWrapper) Stop() {
 
 func NewJobsEventWatcher(collection *CronJobCollection) *WatchWrapper {
 	clientset := collection.clientset
-	// timeOut := int64(10)
 	namespace := corev1.NamespaceAll
 	if collection.kubernetesNamespace != "" {
 		namespace = collection.kubernetesNamespace


### PR DESCRIPTION
The watch API cannot be used indefinitely -- eventually the stream of events stops and the watcher closes the channel. This is expected (on our clusters a watch stops after around 45 minutes). The API provides a RetryWatcher that handles this very situation. This PR adds in the RetryWatcher. With out retry,  the agent will stop updating the job monitor pretty quickly