### PR TITLE
Allow disalbe send auto-complete ping

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Here is the list of supported annotations:
 * `k8s.cronitor.io/cronitor-notify` - Comma-separated list of Notification List `key`s to assign alert destinations.
 * `k8s.cronitor.io/cronitor-group` - Group `key` attribute for grouping the monitor within the Cronitor application.
 * `k8s.cronitor.io/cronitor-grace-seconds` - The number of seconds that Cronitor should wait after the scheduled execution time before sending an alert. If the monitor is healthy at the end of the period no alert will be sent.
+* `k8s.cronitor.io/log-complete-event` - Controls whether the job completion event should be sent as a log record instead of a stateful completion. When set to `true`, the agent will not send telemetry events with state=complete, but will send a log event recording the completion. This supports async workflows where the actual task completion occurs outside the Kubernetes job. Valid values are `"true"` or `"false"`, default is `false`.
 
 ### FAQ
 <details>

--- a/e2e-test/resources/main/cronjob-log-complete-event-annotation.yaml
+++ b/e2e-test/resources/main/cronjob-log-complete-event-annotation.yaml
@@ -1,0 +1,19 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: test-log-complete-event-annotation
+  annotations:
+    k8s.cronitor.io/log-complete-event: "true"
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      backoffLimit: 3
+      template:
+        spec:
+          containers:
+            - name: hello
+              image: busybox
+              args: [/bin/sh, -c, date ; sleep 5 ; echo Hello from k8s]
+          restartPolicy: OnFailure
+  concurrencyPolicy: Forbid


### PR DESCRIPTION
This PR introduces annotation-based control for completion reporting in asynchronous task workflows:

**Problem Addressed**
- Misleading status reporting for async queue-based processing (#47)

**Implementation Highlights**
```yaml
apiVersion: batch/v1
kind: CronJob
metadata:
  annotations:
    k8s.cronitor.io/auto-complete: "false" # Opt-out of pod-exit completion
```

 **Verification Steps** 
1. Use `skaffold` to deploy the application: `skaffold run`
2. Deploy the test CronJob with the auto-complete annotation:
```shell
kubectl apply -f e2e-test/resources/main/cronjob-auto-complete-annotation.yaml
```
![image](https://github.com/user-attachments/assets/496c48d0-886b-43b4-8c26-5c4ec0fbc281)
