### PR TITLE
Ship logs only on terminal events to avoid duplicates

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Control alert behavior for this monitor.
 |------------|-------------|--------|---------|
 | `k8s.cronitor.io/note` | A note displayed on the monitor in the Cronitor dashboard. Useful for documentation or runbook links. | Any string | None |
 | `k8s.cronitor.io/log-complete-event` | Send job completion as a log event instead of a state change. Use for async workflows where the actual task completion occurs outside the Kubernetes job. | `"true"`, `"false"` | `"false"` |
+| `k8s.cronitor.io/send-pod-start-event` | Send an additional `run` event when the Pod container starts. By default, only the Job-level `SuccessfulCreate` event triggers a `run`. Enable this if you need a more precise "code is executing" timestamp — for example, when image pull or scheduling delays make the Job creation time inaccurate for duration tracking. | `"true"`, `"false"` | `"false"` |
 
 #### Legacy annotation names
 

--- a/pkg/annotations.go
+++ b/pkg/annotations.go
@@ -108,6 +108,13 @@ const (
 	// The only valid values are "true" and "false". Default is "false".
 	AnnotationLogCompleteEvent CronitorAnnotation = "k8s.cronitor.io/log-complete-event"
 
+	// AnnotationSendPodStartEvent controls whether Pod "Started" events are sent as run telemetry.
+	// By default, the agent does NOT send a run event for Pod Started events because the Job-level
+	// SuccessfulCreate event already triggers a run. Set to "true" to opt in to the additional
+	// Pod Started → run telemetry.
+	// The only valid values are "true" and "false". Default is "false".
+	AnnotationSendPodStartEvent CronitorAnnotation = "k8s.cronitor.io/send-pod-start-event"
+
 	// AnnotationMetricDuration lets you set duration assertions on the monitor.
 	// The value should be a comparison string starting with "<" or ">", followed by a number and an optional time unit.
 	// Multiple assertions can be comma-separated.
@@ -354,6 +361,19 @@ func (cronitorParser CronitorConfigParser) LogCompleteEvent() (bool, error) {
 	}
 
 	return false, nil
+}
+
+// SendPodStartEvent returns whether Pod "Started" events should generate run telemetry.
+// Default is false — the Job-level SuccessfulCreate already sends a run event.
+func (cronitorParser CronitorConfigParser) SendPodStartEvent() bool {
+	if raw, ok := cronitorParser.cronjob.Annotations[string(AnnotationSendPodStartEvent)]; ok {
+		val, err := strconv.ParseBool(raw)
+		if err != nil {
+			return false
+		}
+		return val
+	}
+	return false
 }
 
 // GetMetricDuration returns the raw metric.duration annotation value.

--- a/pkg/annotations_test.go
+++ b/pkg/annotations_test.go
@@ -547,6 +547,56 @@ func TestGetMetricDuration(t *testing.T) {
 	}
 }
 
+func TestSendPodStartEvent(t *testing.T) {
+	tests := []struct {
+		name          string
+		annotation    string
+		expectedValue bool
+	}{
+		{
+			name:          "true annotation",
+			annotation:    "true",
+			expectedValue: true,
+		},
+		{
+			name:          "false annotation",
+			annotation:    "false",
+			expectedValue: false,
+		},
+		{
+			name:          "invalid annotation defaults to false",
+			annotation:    "invalid",
+			expectedValue: false,
+		},
+		{
+			name:          "no annotation defaults to false",
+			annotation:    "",
+			expectedValue: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var annotations []Annotation
+			if tc.annotation != "" {
+				annotations = []Annotation{
+					{Key: "k8s.cronitor.io/send-pod-start-event", Value: tc.annotation},
+				}
+			}
+
+			cronJob, err := CronJobFromAnnotations(annotations)
+			if err != nil {
+				t.Fatalf("failed to create CronJob from annotations: %v", err)
+			}
+
+			parser := NewCronitorConfigParser(&cronJob)
+			if got := parser.SendPodStartEvent(); got != tc.expectedValue {
+				t.Errorf("SendPodStartEvent() = %v, want %v", got, tc.expectedValue)
+			}
+		})
+	}
+}
+
 func TestGetNote(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/pkg/collector/jobevent_watcher.go
+++ b/pkg/collector/jobevent_watcher.go
@@ -339,6 +339,15 @@ func (e EventHandler) OnAdd(obj interface{}) {
 			return
 		}
 
+		// By default, skip Pod "Started" → run events because the Job-level SuccessfulCreate
+		// already sends a run event. Users can opt in via the send-pod-start-event annotation.
+		if typedEvent.Reason == "Started" && !pkg.NewCronitorConfigParser(cronjob).SendPodStartEvent() {
+			slog.Debug("pod Started event skipped (opt in via send-pod-start-event annotation)",
+				"namespace", podNamespace,
+				"pod", podName)
+			return
+		}
+
 		slog.Info("pod event added",
 			"name", typedEvent.InvolvedObject.Name,
 			"kind", typedEvent.InvolvedObject.Kind,


### PR DESCRIPTION
Previously, every Kubernetes event (SuccessfulCreate, Started, Completed, BackoffLimitExceeded, BackOff) independently fetched and shipped the same pod logs, causing 2-3 duplicate log events per job execution.

Now logs are only fetched on terminal events:
- Job: Completed, BackoffLimitExceeded
- Pod: BackOff

Run events (SuccessfulCreate, Started) skip log fetching entirely. This eliminates duplicate log shipments and reduces unnecessary API calls on non-terminal events.